### PR TITLE
Replace job URL by just job name

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The following variables are available for formatting your own strings.
 - {repo_url}
 - {status_message}
 - {run_url}
-- {job_url}
+- {job}
 - {workflow}
 - {workflow_url}
 

--- a/main.py
+++ b/main.py
@@ -102,6 +102,7 @@ def construct_payload(inputs):
         commit_url=f'https://github.com/{repo}/commit/{commit_sha}',
         repo_url=f'https://github.com/{repo}',
         run_url=f'https://github.com/{repo}/actions/runs/{run_id}',
+        job_url=f'https://github.com/{repo}/runs/{job_id}',
         workflow=workflow,
         workflow_url=get_workflow_url(inputs),
         color=action_color(job_status),

--- a/main.py
+++ b/main.py
@@ -82,7 +82,7 @@ def construct_payload(inputs):
     branch = os.getenv('GITHUB_REF')
     commit_sha = os.getenv('GITHUB_SHA')[:7]
     run_id = os.getenv('GITHUB_RUN_ID')
-    job_id = os.getenv('GITHUB_JOB')
+    job = os.getenv('GITHUB_JOB')
 
     # derived from action inputs
     job_status = inputs['job_status']
@@ -102,7 +102,7 @@ def construct_payload(inputs):
         commit_url=f'https://github.com/{repo}/commit/{commit_sha}',
         repo_url=f'https://github.com/{repo}',
         run_url=f'https://github.com/{repo}/actions/runs/{run_id}',
-        job_url=f'https://github.com/{repo}/runs/{job_id}',
+        job=job,
         workflow=workflow,
         workflow_url=get_workflow_url(inputs),
         color=action_color(job_status),


### PR DESCRIPTION
turned to be that two parallel PRs were in collision, the #25 added new `job_url` but the #26 with refactoring was based on master so it did not include `job_url` among patterns...