### PR TITLE
Change base image from docker hub to ECR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim AS builder
+FROM public.ecr.aws/docker/library/python:3-slim AS builder
 ADD . /app
 WORKDIR /app
 


### PR DESCRIPTION
Because of DockerHub [rate limits](https://docs.docker.com/docker-hub/download-rate-limit/#:~:text=Docker%20Hub%20limits%20the%20number,pulls%20per%206%20hour%20period.), if we run this github action on self-hosted runners we might get rate limited after 100 calls. If we use [ECR public images](https://www.docker.com/blog/news-from-aws-reinvent-docker-official-images-on-amazon-ecr-public/) instead, this problem doesn't apply since the rate limit is bigger.