### PR TITLE
chore(deps): Update runtime from node16 to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,5 +67,5 @@ branding:
   color: blue
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@types/jest": "28.1.8",
-        "@types/node": "^18.0.0",
+        "@types/node": "^20.11.16",
         "@types/node-fetch": "^2.6.2",
         "@typescript-eslint/parser": "5.53.0",
         "@vercel/ncc": "^0.36.0",
@@ -1515,10 +1515,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
-      "dev": true
+      "version": "20.11.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.16.tgz",
+      "integrity": "sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -6438,6 +6441,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/universal-user-agent": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
@@ -7885,10 +7894,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
-      "dev": true
+      "version": "20.11.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.16.tgz",
+      "integrity": "sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/node-fetch": {
       "version": "2.6.2",
@@ -11456,6 +11468,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "universal-user-agent": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/jest": "28.1.8",
-    "@types/node": "^18.0.0",
+    "@types/node": "^20.11.16",
     "@types/node-fetch": "^2.6.2",
     "@typescript-eslint/parser": "5.53.0",
     "@vercel/ncc": "^0.36.0",


### PR DESCRIPTION
Fixes #126

As long is this is being applied for a new release, also consider upgrading other deps.
See #125
