### PR TITLE
build: use node20 instead of node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,5 +67,5 @@ branding:
   color: blue
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
Node16 is deprecated in Github Action
A previous PR has been made but the `action.yml` has been forgotten