### PR TITLE
chore: bump node version from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,5 +67,5 @@ branding:
   color: blue
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
Soon to a requirement from Github.

Fixes: _#143_

## QA Log

- Compiles with Node 24.